### PR TITLE
Fix HUD vanishing after closing the Instant Actions menu

### DIFF
--- a/StarControl.Gmcm/StarControl.Gmcm.csproj
+++ b/StarControl.Gmcm/StarControl.Gmcm.csproj
@@ -50,8 +50,22 @@
       <ProjectReference Include="..\StarControl\StarControl.csproj" />
     </ItemGroup>
 
-    <Target Name="Deploy" AfterTargets="Build">
-        <Copy SourceFiles="$(OutDir)StarControl.Gmcm.dll" DestinationFolder="$(SolutionDir)StarControl\assets\extensions" ContinueOnError="false" />
+    <!--
+        StarControl loads this extension at runtime from its deployed mod folder's
+        assets/extensions/ directory (see ModEntry: Helper.DirectoryPath/assets/extensions/
+        StarControl.Gmcm.dll). This project doesn't deploy itself (EnableModDeploy=False),
+        so copy the built DLL straight into StarControl's deployed assets/extensions folder.
+        The ProjectReference above ensures StarControl is built and deployed first, so the
+        target folder exists. Only StarControl.Gmcm.dll is needed; its dependencies resolve
+        against assemblies StarControl has already loaded.
+    -->
+    <Target Name="DeployGmcmExtension" AfterTargets="Build" Condition="'$(GameModsPath)' != ''">
+        <PropertyGroup>
+            <StarControlExtensionsDir>$(GameModsPath)\Star Control - CustomisationPlus\assets\extensions</StarControlExtensionsDir>
+        </PropertyGroup>
+        <MakeDir Directories="$(StarControlExtensionsDir)" />
+        <Copy SourceFiles="$(OutDir)StarControl.Gmcm.dll" DestinationFolder="$(StarControlExtensionsDir)" SkipUnchangedFiles="true" />
+        <Message Importance="high" Text="Deployed GMCM extension to $(StarControlExtensionsDir)" />
     </Target>
 
 </Project>

--- a/StarControl/ModEntry.cs
+++ b/StarControl/ModEntry.cs
@@ -525,6 +525,13 @@ public class ModEntry : Mod
         var controller = ViewEngine.OpenRootMenu("Remapping", context);
         context.Controller = controller;
         controller.PositionSelector = context.GetMenuPosition;
+        // StardewUI's menu sets Game1.displayHUD = false while it's open and never restores
+        // it on close, which permanently hides the HUD (and the latched value then poisons
+        // the radial wheel's own HUD save/restore on the next open). Capture the HUD state
+        // and restore it when the menu closes. Note: the Closing event (cleanupBeforeExit
+        // lifecycle) is the one that fires at actual close time; Closed fires at open.
+        var hudWasVisible = Game1.displayHUD;
+        controller.Closing += () => Game1.displayHUD = hudWasVisible;
         Game1.activeClickableMenu = controller!.Menu;
     }
 


### PR DESCRIPTION
StardewUI's menu (DocumentViewMenu) sets Game1.displayHUD = false while open and never restores it on close. Because the radial wheel has already closed by the time that menu opens, StarControl's own HUD save/restore never covers it, so the HUD stayed hidden after closing Instant Actions -- and the latched-off value then poisoned the wheel's HUD capture on the next open, requiring F4 to recover.

Capture the HUD state in OpenRemappingMenu and restore it via the menu controller's Closing event (the cleanupBeforeExit lifecycle hook that fires at actual close time; Closed fires at open).